### PR TITLE
Add postinstall script for TS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "nodemon --exec \"npm start\"",
+    "postinstall": "npm run build",
     "start": "probot run ./build/index.js",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"


### PR DESCRIPTION
This ensures the script that generates the build/ directory will be available right after doing `npm install`. Heroku should honor this script when you push to their platform and will not attempt to start the server until _after_ the typescript build is complete. See https://docs.npmjs.com/misc/scripts#examples for more info