### PR TITLE
Fix return value from first promise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export = (app: Application) => {
         })
             .then((res: { json: () => void }) => { 
                 console.log(res);
-                res.json();
+                return res.json();
             })
             .then( (anomalies: Array<Fixrbot.Anomaly>) => {
                         console.log(anomalies);


### PR DESCRIPTION
Fix the issue with the use of fetch --- the first fetch did not return the `res.json()` promise.

This caused the anomaly vector to be undefined in the next "then".